### PR TITLE
Re-correct locale setting.

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -4,7 +4,7 @@ Common functions for the build system
 
 """
 from __future__ import print_function
-
+import locale
 import sys
 import subprocess
 import platform
@@ -155,10 +155,10 @@ def try_execute(*args, **kwargs):
         else:
             output = subprocess.check_output(args, bufsize=1, stderr=subprocess.STDOUT)
             debug_out("Process output: ")
-            debug_out(output.decode("chcp", errors="ignore"))
+            debug_out(output.decode(locale.getpreferredencoding(), errors="ignore"))
     except subprocess.CalledProcessError as msg:
         debug_out("Process error:")
-        debug_out(msg.output.decode("chcp", errors="ignore"))
+        debug_out(msg.output.decode(locale.getpreferredencoding(), errors="ignore"))
         fatal_error("Subprocess returned no-zero statuscode!")
 
 def join_abs(*args):


### PR DESCRIPTION
I made you confused, sorry for that.
On CMD, chcp command returns current Active Code Page (ACP) and that's what i wanted for compatibility on another language
To do the same thing in python, I import locale module and use locale.getpreferredencoding() func, and it'll return current enviroment's Active Code Page.
