### PR TITLE
Add support for FreeBSD

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,7 +176,11 @@ else()
 
   # [LIB] Eigen 3
   if (HAVE_LIB_EIGEN)
-    include_directories(BEFORE "/usr/include/eigen3/")
+    if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+      include_directories(BEFORE "/usr/local/include/eigen3/")
+    else()
+      include_directories(BEFORE "/usr/include/eigen3/")
+    endif()
 
     # Eigen build flags (sync with Panda)
     if (HAVE_LIB_EIGEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,20 +33,19 @@ set(CMAKE_CXX_FLAGS_RELEASE "")
 set(CMAKE_CXX_FLAGS_MINSIZEREL "")
 
 
-if (CMAKE_CL_64 STREQUAL "1")
-  message(STATUS "Bitness: 64 bit ('${CMAKE_CL_64}')")
-  set(IS_64_BIT TRUE)
-  set(IS_32_BIT FALSE)
-else()
-  message(STATUS "Bitness: 32 bit ('${CMAKE_CL_64}')")
-  set(IS_64_BIT TRUE)
-  set(IS_32_BIT FALSE)
-endif()
-
 set(LIBRARIES "")
 
 # Windows - 32 and 64 bit
 if (WIN32)
+  if (CMAKE_CL_64 STREQUAL "1")
+    message(STATUS "Bitness: 64 bit ('${CMAKE_CL_64}')")
+    set(IS_64_BIT TRUE)
+    set(IS_32_BIT FALSE)
+  else()
+    message(STATUS "Bitness: 32 bit ('${CMAKE_CL_64}')")
+    set(IS_64_BIT TRUE)
+    set(IS_32_BIT FALSE)
+  endif()
 
   set(PYTHONVER CACHE STRING "27")
 

--- a/scripts/common.py
+++ b/scripts/common.py
@@ -90,7 +90,7 @@ def get_panda_bin_path():
     """ Returns the path to the panda3d binaries """
     if is_windows():
         return first_existing_path([join(get_panda_sdk_path(), "bin")], "interrogate.exe")
-    elif is_linux():
+    elif is_linux() or is_freebsd():
         libpath = get_panda_lib_path()
         search = [
             join(libpath, "../bin"),
@@ -107,7 +107,7 @@ def get_panda_lib_path():
     """ Returns the path to the panda3d libraries """
     if is_windows():
         return first_existing_path([join(get_panda_sdk_path(), "lib")], "libpanda.lib")
-    elif is_linux() or is_macos():
+    elif is_linux() or is_macos() or is_freebsd():
         return dirname(ExecutionEnvironment.get_dtool_name())
     raise NotImplementedError("Unsupported OS")
 
@@ -116,7 +116,7 @@ def get_panda_include_path():
     """ Returns the path to the panda3d includes """
     if is_windows() or is_macos():
         return first_existing_path([join(get_panda_sdk_path(), "include")], "dtoolbase.h")
-    elif is_linux():
+    elif is_linux() or is_freebsd():
         libpath = get_panda_lib_path()
         search = [
             join(libpath, "../include/"),
@@ -157,6 +157,10 @@ def is_linux():
 def is_macos():
     """ Returns whether the build system is macos (darwin) """
     return platform.system().lower() == "darwin"
+
+def is_freebsd():
+    """ Returns whether the build system is freebsd """
+    return platform.system().lower() == "freebsd"
 
 
 def get_compiler_name():

--- a/scripts/finalize.py
+++ b/scripts/finalize.py
@@ -6,7 +6,7 @@ import sys
 
 from shutil import copyfile
 from os.path import isfile, join
-from common import is_windows, is_linux, is_macos, get_output_dir, fatal_error, get_script_dir
+from common import is_windows, get_output_dir, fatal_error, get_script_dir
 
 
 def find_binary():
@@ -25,7 +25,7 @@ def find_binary():
         for config in configurations:
             possible_files.append(join(get_output_dir(), config, MODULE_NAME + ".dll"))
 
-    elif is_linux() or is_macos():
+    else:
         target_file = MODULE_NAME + ".so"
         possible_files.append(join(get_output_dir(), target_file))
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -10,7 +10,7 @@ from .common import get_output_dir, try_makedir, fatal_error, is_windows
 from .common import is_linux, join_abs, get_panda_lib_path, is_64_bit
 from .common import try_execute, get_script_dir, get_panda_mscv_version
 from .common import have_eigen, have_bullet, have_freetype, print_error
-from .common import is_macos
+from .common import is_macos, is_freebsd
 
 
 def make_output_dir(clean=False):
@@ -93,7 +93,7 @@ def run_cmake(config, args):
     if is_windows():
         cmake_args += ["-DPYTHONVER:STRING=" + pyver]
 
-    if is_linux():
+    if is_linux() or is_freebsd():
         cmake_args += ["-DPYTHONVERDOT:STRING=" + pyver_dot]
 
     # Libraries
@@ -152,7 +152,7 @@ def run_cmake_build(config, args):
     num_cores = max(1, multiprocessing.cpu_count() - 1)
 
     core_option = ""
-    if is_linux() or is_macos():
+    if is_linux() or is_macos() or is_freebsd():
         # On linux, use all available cores
         core_option = "-j" + str(num_cores)
     if is_windows():


### PR DESCRIPTION
As the title states; this was needed to build LUI on FreeBSD.

Also, changes the "bitness" message to only display on Windows.  On other platforms, it erroneously reports "32-bits", which is misleading, since it isn't actually being used on non-Windows platforms.