### PR TITLE
find_sources(): find more valid file extensions

### DIFF
--- a/scripts/interrogate.py
+++ b/scripts/interrogate.py
@@ -8,6 +8,7 @@ Runs the interrogate and interrogate_module commands from Panda3D.
 import sys
 from os import listdir, chdir
 from os.path import join, isfile, isdir
+import re
 
 from panda3d.core import PandaSystem
 from common import debug_out, get_panda_bin_path, get_panda_include_path
@@ -35,9 +36,10 @@ def find_sources(base_dir):
     """ Collects all header files recursively """
     sources = []
     files = listdir(base_dir)
+    p = re.compile(r'.*\.(h|c)((pp|xx)?)$', flags=re.I)
     for f in files:
         fpath = join(base_dir, f)
-        if isfile(fpath) and check_ignore(f) and f.endswith(".h"):
+        if isfile(fpath) and check_ignore(f) and  p.match(f) is not None:
             if f.endswith(".pb.h"):
                 continue # Skip protobuf
             sources.append(fpath)


### PR DESCRIPTION
I had a problem getting my project to compile due to file extensions used (`.hpp`). Right now the method `find_sources()` in [interrogate.py](/tobspr/P3DModuleBuilder/blob/master/scripts/interrogate.py) only returns files that end with `.h`

I added a regular expression that matches files with extensions: 

- `.c`
- `.cpp`
- `.cxx`
- `.h`
- `.hpp`
- `.hxx`

If `.c` should be excluded, the expression would change to `'.*\.(h(pp|xx)?|c(pp|xx))$'` to match the above list, excluding the `.c` extension.
