### PR TITLE
Added support for Visual Studio 2017 and 2019

### DIFF
--- a/scripts/common.py
+++ b/scripts/common.py
@@ -33,7 +33,25 @@ MSVC_VERSIONS = [
     MSVCVersion(1600, "Visual Studio 10 2010", "vc100"),
     MSVCVersion(1700, "Visual Studio 11 2012", "vc110"),
     MSVCVersion(1800, "Visual Studio 12 2013", "vc120"),
-    MSVCVersion(1900, "Visual Studio 14 2015", "vc140")
+    MSVCVersion(1900, "Visual Studio 14 2015", "vc140"),
+    
+    MSVCVersion(1910, "Visual Studio 15 2017", "vc141"),
+    MSVCVersion(1911, "Visual Studio 15 2017", "vc141"),
+    MSVCVersion(1912, "Visual Studio 15 2017", "vc141"),
+    MSVCVersion(1913, "Visual Studio 15 2017", "vc141"),
+    MSVCVersion(1914, "Visual Studio 15 2017", "vc141"),
+    MSVCVersion(1915, "Visual Studio 15 2017", "vc141"),
+    MSVCVersion(1916, "Visual Studio 15 2017", "vc141"),
+    
+    MSVCVersion(1920, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1921, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1922, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1923, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1924, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1925, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1926, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1927, "Visual Studio 16 2019", "vc142"),
+    MSVCVersion(1928, "Visual Studio 16 2019", "vc142")
 ]
 
 def get_output_name():

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -85,9 +85,9 @@ def run_cmake(config, args):
             cmake_args += ["-DINTERROGATE_LIB:STRING=core"]
 
     if is_windows():
+        cmake_args += ["-G" + get_panda_msvc_version().cmake_str]
         # Specify 64-bit compiler when using a 64 bit panda sdk build
-        bit_suffix = " Win64" if is_64_bit() else ""
-        cmake_args += ["-G" + get_panda_msvc_version().cmake_str + bit_suffix]
+        cmake_args += ["-Ax64"] if is_64_bit() else ["-AWin32"]
     elif is_macos():
         # Panda is 64-bit only on macOS.
         cmake_args += ["-DCMAKE_CL_64:STRING=1"]


### PR DESCRIPTION
I added the MSVC version codes for newer Visual Studio versions so they can be recognized. Also, the Visual Studio 16 2019 cmake generator doesn't support specifying the architecture at the end of the generator name, so it is specified with -A instead.