### PR TITLE
Support Modern Panda3D, CMake, and Visual Studio.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,7 @@
+cmake_minimum_required(VERSION 3.16)
 
 set(PROJECT_NAME CACHE STRING "Module")
-
-cmake_minimum_required (VERSION 2.6)
-project (${PROJECT_NAME})
+project(${PROJECT_NAME})
 
 # Project configuration
 set(CMAKE_BUILD_TYPE "Release")
@@ -71,11 +70,19 @@ if (WIN32)
     set(MSVC_VERSION_SHORT "vc10")
   elseif (MSVC12)
     set(MSVC_VERSION_SHORT "vc12")
-  elseif(MSVC14)
+  elseif(MSVC_VERSION LESS 1910)
     set(MSVC_VERSION_SHORT "vc14")
+  elseif(MSVC_VERSION LESS 1920)
+    set(MSVC_VERSION_SHORT "vc141")
+  elseif(MSVC_VERSION LESS 1930)
+    set(MSVC_VERSION_SHORT "vc142")
+  elseif(MSVC_VERSION LESS 1950)
+    set(MSVC_VERSION_SHORT "vc143")
+  elseif(MSVC_VERSION LESS 1960)
+    set(MSVC_VERSION_SHORT "vc144")
   else()
-    message(WARMING "Unable to determine visual studio version, assuming Visual Studio 2015")
-    set(MSVC_VERSION_SHORT "vc14")
+    message(WARNING "Unable to determine visual studio version, assuming latest")
+    set(MSVC_VERSION_SHORT "vc144")
   endif()
   message(STATUS "Detected visual studio version: ${MSVC_VERSION_SHORT}")
 
@@ -258,7 +265,7 @@ if (NOT ("${IGATE_VERBOSE}" STREQUAL "0" ))
 endif()
 
 if(NOT ("${return_code}" STREQUAL "0"))
-    message(FATAL_ERROR "Interrogate failed: ${output} ${errors}")
+    message(FATAL_ERROR "Interrogate failed. Make sure panda3d-interrogate is installed:\n  pip install panda3d-interrogate\n\n${output} ${errors}")
 endif()
 
 # Set compiler flags

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -75,7 +75,18 @@ def run_cmake(config, args):
 
     # Check for the right interrogate lib
     if PandaSystem.get_major_version() > 1 or PandaSystem.get_minor_version() > 9:
-        cmake_args += ["-DINTERROGATE_LIB:STRING=" + lib_prefix + "p3interrogatedb"]
+        # Prefer p3interrogatedb if available, otherwise fall back
+        interrogatedb_lib = lib_prefix + "p3interrogatedb"
+        if is_windows():
+            interrogatedb_path = join_abs(get_panda_lib_path(), interrogatedb_lib + ".lib")
+        else:
+            interrogatedb_path = join_abs(get_panda_lib_path(), interrogatedb_lib + ".so")
+
+        if isfile(interrogatedb_path):
+            cmake_args += ["-DINTERROGATE_LIB:STRING=" + interrogatedb_lib]
+        else:
+            # In newer Panda3D SDKs, interrogatedb is linked into libpanda
+            cmake_args += ["-DINTERROGATE_LIB:STRING=" + lib_prefix + "panda"]
     else: 
 
         # Buildbot versions do not have the core lib, instead try using libpanda


### PR DESCRIPTION
I'm sure there will likely be feedback but I'm considering this a first attempt at upgrading the module builder for the latest Visual Studio, CMake, and Panda3D so I can continue to do C++ development for the engine.

**Visual Studio version detection and support:**
- Expanded detection and assignment of `MSVC_VERSION_SHORT` in `CMakeLists.txt` to support Visual Studio versions up to 2026 (`vc144`), with improved logic and warnings for unknown versions.
- Updated the list of recognized MSVC versions in `scripts/common.py` to include all minor versions of 2022 (`vc143`) and added entries for the upcoming 2026 release (`vc144`).

**Interrogate binary discovery and error handling:**
- Enhanced the logic in `scripts/common.py` to locate the `interrogate` binary by first checking pip-installed locations, then the system PATH, and finally the SDK, with clear error messages and installation hints if not found.
- Improved error message in `CMakeLists.txt` when `interrogate` is missing, now suggesting installation via pip for easier troubleshooting.

**Build and setup robustness:**
- Updated `scripts/setup.py` to check for the presence of the `p3interrogatedb` library and fall back to `libpanda` if not available, improving compatibility with newer Panda3D SDKs.